### PR TITLE
Issue #44: Update dependencies

### DIFF
--- a/components-health-typesystem/pom.xml
+++ b/components-health-typesystem/pom.xml
@@ -22,8 +22,8 @@
 		<!-- Ruta -->
 		<dependency>
 			<groupId>org.apache.uima</groupId>
-			<artifactId>ruta-typesystem</artifactId>
-			<version>${ruta-typesystems-version}</version>
+			<artifactId>ruta-core</artifactId>
+			<version>${ruta-version}</version>
 		</dependency>
 
 		<!-- Core -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,12 @@
 	<url>https://github.com/averbis/health-typesystems</url>
 
 	<properties>
-		<uima-version>3.4.0-SNAPSHOT</uima-version>
-		<uimafit-version>3.4.0-SNAPSHOT</uimafit-version>
+		<uima-version>3.4.0</uima-version>
+		<uimafit-version>3.4.0</uimafit-version>
 		<ruta-version>3.3.0-SNAPSHOT</ruta-version>
-		<core-typesystems-version>4.4.0-SNAPSHOT</core-typesystems-version>
-		<junit-jupiter-version>5.9.1</junit-jupiter-version>
-		<assertj-version>3.23.1</assertj-version>
+		<core-typesystems-version>4.4.0</core-typesystems-version>
+		<junit-jupiter-version>5.9.2</junit-jupiter-version>
+		<assertj-version>3.24.2</assertj-version>
 		<slf4j-version>1.7.36</slf4j-version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
 	<properties>
 		<uima-version>3.4.0-SNAPSHOT</uima-version>
 		<uimafit-version>3.4.0-SNAPSHOT</uimafit-version>
+		<ruta-version>3.3.0-SNAPSHOT</ruta-version>
 		<core-typesystems-version>4.4.0-SNAPSHOT</core-typesystems-version>
-		<ruta-typesystems-version>3.3.0-SNAPSHOT</ruta-typesystems-version>
 		<junit-jupiter-version>5.9.1</junit-jupiter-version>
 		<assertj-version>3.23.1</assertj-version>
 		<slf4j-version>1.7.36</slf4j-version>


### PR DESCRIPTION
- Replace dependency on ruta-typesystem with a dependency on ruta-core which contains the type system for ruta 3.4.0+
- uima 3.4.0-SNAPSHOT -> 3.4.0
- uimafit 3.4.0-SNAPSHOT -> 3.4.0
- core-typesystems 4.4.0-SNAPSHOT -> 4.4.0
- junit 5.9.1 -> 5.9.2
- assertj 3.23.1 -> 3.24.2